### PR TITLE
Standardized instatiation value types

### DIFF
--- a/lib/Int.ts
+++ b/lib/Int.ts
@@ -33,17 +33,17 @@ const IntFactory = <T>(size: number) => (identifier: object) => pipe(
     Object.freeze,
 );
 
-const Int8 = (value?: number | string | BigNumber): Int8 => IntFactory<Int8>(8)({_int8: true})(value);
+const Int8 = (value?: string | BigNumber): Int8 => IntFactory<Int8>(8)({_int8: true})(value);
 
-const Int16 = (value?: number | string | BigNumber): Int16 => IntFactory<Int16>(16)({_int16: true})(value);
+const Int16 = (value?: string | BigNumber): Int16 => IntFactory<Int16>(16)({_int16: true})(value);
 
-const Int32 = (value?: number | string | BigNumber): Int32 => IntFactory<Int32>(32)({_int32: true})(value);
+const Int32 = (value?: string | BigNumber): Int32 => IntFactory<Int32>(32)({_int32: true})(value);
 
-const Int64 = (value?: string): Int64 => IntFactory<Int64>(64)({_int64: true})(value);
+const Int64 = (value?: string | BigNumber): Int64 => IntFactory<Int64>(64)({_int64: true})(value);
 
-const Int128 = (value?: string): Int128 => IntFactory<Int128>(128)({_int128: true})(value);
+const Int128 = (value?: string | BigNumber): Int128 => IntFactory<Int128>(128)({_int128: true})(value);
 
-const Int256 = (value?: string): Int256 => IntFactory<Int256>(256)({_int256: true})(value);
+const Int256 = (value?: string | BigNumber): Int256 => IntFactory<Int256>(256)({_int256: true})(value);
 
 // Type Checkers
 const isInt8 = (x: Int): x is Int8 => (x as Int8)._int8;

--- a/lib/Uint.ts
+++ b/lib/Uint.ts
@@ -36,17 +36,17 @@ const UintFactory = <T>(size: number) => (identifier: object) => pipe(
     Object.freeze,
 );
 
-const Uint8 = (value?: number | string | BigNumber): Uint8 => UintFactory<Uint8>(8)({_uint8: true})(value);
+const Uint8 = (value?: string | BigNumber): Uint8 => UintFactory<Uint8>(8)({_uint8: true})(value);
 
-const Uint16 = (value?: number | string | BigNumber): Uint16 => UintFactory<Uint16>(16)({_uint16: true})(value);
+const Uint16 = (value?: string | BigNumber): Uint16 => UintFactory<Uint16>(16)({_uint16: true})(value);
 
-const Uint32 = (value?: number | string | BigNumber): Uint32 => UintFactory<Uint32>(32)({_uint32: true})(value);
+const Uint32 = (value?: string | BigNumber): Uint32 => UintFactory<Uint32>(32)({_uint32: true})(value);
 
-const Uint64 = (value?: string): Uint64 => UintFactory<Uint64>(64)({_uint64: true})(value);
+const Uint64 = (value?: string | BigNumber): Uint64 => UintFactory<Uint64>(64)({_uint64: true})(value);
 
-const Uint128 = (value?: string): Uint128 => UintFactory<Uint128>(128)({_uint128: true})(value);
+const Uint128 = (value?: string | BigNumber): Uint128 => UintFactory<Uint128>(128)({_uint128: true})(value);
 
-const Uint256 = (value?: string): Uint256 => UintFactory<Uint256>(256)({_uint256: true})(value);
+const Uint256 = (value?: string | BigNumber): Uint256 => UintFactory<Uint256>(256)({_uint256: true})(value);
 
 // Type Checkers
 const isUint8 = (x: Uint): x is Uint8 => (x as Uint8)._uint8;

--- a/lib/utils/inputParsers.ts
+++ b/lib/utils/inputParsers.ts
@@ -8,13 +8,11 @@ import { FloatingPointNotSupportedError, InvalidSizeError } from "../errors";
 const emptyValueToZero = (x) => x ? x : 0;
 const notFloat = (x: number): boolean => x % 1 === 0;
 
-const inputTypeToBigNumber = (value?: number | string | BigNumber): BigNumber | Error => {
+const inputTypeToBigNumber = (value?: string | BigNumber): BigNumber | Error => {
     if (value instanceof BigNumber) {
         return value.isInteger() ? value : new FloatingPointNotSupportedError();
     } else if (typeof value === "string") {
         return notFloat(parseInt(value, 10)) ? new BigNumber(value) : new FloatingPointNotSupportedError();
-    } else if (typeof value === "number") {
-        return notFloat(value) ? new BigNumber(value) : new FloatingPointNotSupportedError();
     }
 };
 

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -3,8 +3,7 @@ import { TypeNotSupportedError } from "../errors";
 import { MetaInteger } from "../Interfaces";
 
 const getSize = (num) => {
-    if (typeof num === "number") { return getNumberSize(num);
-    } else if (typeof num === "string") { return getStringNumberSize(num);
+    if (typeof num === "string") { return getStringNumberSize(num);
     } else if (BigNumber.isBigNumber(num)) { return getBigNumberSize(num);
     } else { throw new TypeNotSupportedError(); }
 };


### PR DESCRIPTION
By removing the ability to pass primitive numbers into the factory constructors we simplify our API and prevent misuse. Primitives can still be used by instantiating a BigNumber that is then passed in.

This PR also adds the ability to instantiate 54bit+ numbers with BigNumbers as BNs can handle arbitrary sized values.

Currently working a complete refactoring of the test suite so I have not updated the tests and thus CI will fail. Refactoring PR should be opened by end of day.